### PR TITLE
Add GetReferenceID() method on Response

### DIFF
--- a/response.go
+++ b/response.go
@@ -11,6 +11,7 @@ type Response interface {
 	GetStatusCode() int
 	Failure() bool
 	Message() string
+	GetReferenceID() string
 }
 
 // MainResponse returned by telesign API
@@ -53,4 +54,9 @@ func (r MainResponse) GetStatusCode() int {
 // Message return status description
 func (r MainResponse) Message() string {
 	return r.Status.Description
+}
+
+// GetReferenceID return reference_id from json response
+func (r MainResponse) GetReferenceID() string {
+	return r.ReferenceID
 }


### PR DESCRIPTION
We need to preserve the reference_id so that we can query the status changes in the future.